### PR TITLE
Fix some typos and cleaned up import line

### DIFF
--- a/DDOSA/retrieve.py
+++ b/DDOSA/retrieve.py
@@ -1,14 +1,11 @@
-try:
-    from mw import api
-except:
-    raise
+from mw import api
 
 #Retrieve entries from the recentchanges feed.
 def get_rc(limit, session):
   
   actions = session.recent_changes.query(
-    type = "edit",
-    properties = "ids", "sha1", "timestamp"},
+    type = {"edit", "new"},
+    properties = {"ids", "sha1", "timestamp"},
     direction="newer",
     limit=limit
   )


### PR DESCRIPTION
It turns out that the try/catch around the import was to make the examples work in mediawiki-utilities and it isn't generally required.